### PR TITLE
tiny bug repaired

### DIFF
--- a/.storybook/stories/navbars/navbar/NavbarDark.js
+++ b/.storybook/stories/navbars/navbar/NavbarDark.js
@@ -10,13 +10,28 @@ export class NavbarDark extends React.Component {
     super(props);
     this.state = {
       hidden: true,
+      Width: window.innerWidth,
     };
+    this.handleResize=this.handleResize.bind(this);
   }
 
   handleOpenCloseNav() {
     this.setState({
       hidden: !this.state.hidden,
     });
+  }
+
+  handleResize(e) {
+    this.setState({Width:window.innerWidth});
+  }
+
+  componentDidMount(){
+    window.addEventListener('resize', this.handleResize);
+
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
   }
 
   render() {
@@ -38,7 +53,7 @@ export class NavbarDark extends React.Component {
               </Button>
             </Nav>
           </Nav>
-          <Nav start collapse expandSm hidden={hidden}>
+          <Nav start collapse expandSm hidden={(this.state.Width>576)? false:!hidden}>
             <NavbarLink dark active>Active</NavbarLink>
             <NavbarLink dark href="#">Link</NavbarLink>
             <NavbarLink dark href="#">Link</NavbarLink>

--- a/.storybook/stories/navbars/navbar/NavbarLight.js
+++ b/.storybook/stories/navbars/navbar/NavbarLight.js
@@ -10,7 +10,9 @@ export class NavbarLight extends React.Component {
     super(props);
     this.state = {
       hidden: true,
+      Width: window.innerWidth,
     };
+    this.handleResize=this.handleResize.bind(this);
   }
 
   handleOpenCloseNav() {
@@ -18,6 +20,19 @@ export class NavbarLight extends React.Component {
       hidden: !this.state.hidden,
     });
   }
+
+  handleResize(e) {
+    this.setState({Width:window.innerWidth});
+  }
+
+  componentDidMount(){
+    window.addEventListener('resize', this.handleResize);
+
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  } 
 
   render() {
     const { hidden } = this.state;
@@ -38,7 +53,7 @@ export class NavbarLight extends React.Component {
                 </Button>
               </Nav>
             </Nav>
-            <Nav start collapse expandSm hidden={hidden}>
+            <Nav start collapse expandSm hidden={(this.state.Width>576)? false:!hidden}>
               <NavbarLink light active>Active</NavbarLink>
               <NavbarLink light href="#">Link</NavbarLink>
               <NavbarLink light href="#">Link</NavbarLink>


### PR DESCRIPTION
I found a problem with the Navbar showcase.

If the the NavbarLink items were collapsed by pressing the Button in a small window (width <576) and then resize the window to be larger than 576. The NavbarLink items will never show up again.

I fixed this problem though not in a graceful way. But it worked. Yes, it works now.