### PR TITLE
Docs: fix example in modal readme

### DIFF
--- a/packages/styled-modal-component/README.md
+++ b/packages/styled-modal-component/README.md
@@ -92,25 +92,24 @@ export class MyModal extends React.Component {
                 <Button outline onClick={() => this.handleModal()}>
                   <span aria-hidden="true">&times;</span>
                 </Button>
-                </ModalHeader>
-                <ModalBody>
-                  <p>
-                    Modal Body
-                  </p>
-                </ModalBody>
-                <ModalFooter>
-                  <Button onClick={() => this.handleModal()}>
-                    Close
-                  </Button>
-                </ModalFooter>
               </ModalHeader>
+              <ModalBody>
+                <p>
+                  Modal Body
+                </p>
+              </ModalBody>
+              <ModalFooter>
+                <Button onClick={() => this.handleModal()}>
+                  Close
+                </Button>
+              </ModalFooter>
             </ModalContent>
           </ModalDialog>
         </Modal>
         <Button onClick={() => this.handleModal()} >
           Launch Modal
         </Button>
-      <div>
+      </div>
     );
   }
 };


### PR DESCRIPTION
Example HTML code for modal was not correct. Some errors with closing tags.